### PR TITLE
Tweaks for Scalasca and deps

### DIFF
--- a/easybuild/easyconfigs/c/Cube/Cube-4.3-foss-2015a.eb
+++ b/easybuild/easyconfigs/c/Cube/Cube-4.3-foss-2015a.eb
@@ -21,18 +21,22 @@ description = """Cube, which is used as performance report explorer for Scalasca
 toolchain = {'name': 'foss', 'version': '2015a'}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://apps.fz-juelich.de/scalasca/releases/cube/%(version)s/dist']
+source_urls = ['http://apps.fz-juelich.de/scalasca/releases/cube/%(version_major_minor)s/dist']
 
-
-# patches = ['Cube-4.2_fix-Qt-version-check.patch']
+checksums = [
+    'ed4d6f3647eefa65fc194b5d1a5f4ffe',     # cube-4.3.tar.gz
+]
 
 dependencies = [('Qt', '4.8.6')]
-
-configopts = "QMAKE=$EBROOTQT/bin/qmake MOC=$EBROOTQT/bin/moc UIC=$EBROOTQT/bin/uic"
 
 sanity_check_paths = {
     'files': ["bin/cube", "lib/libcube4.a", "lib/libcube4.so"],
     'dirs': ["include/cube", "include/cubew"],
 }
+
+# If all prerequisites for the Cube Java reader are available on the system,
+# parallel builds will fail. Alternatively, disable the Java reader using
+# configopts = "--without-java-reader"
+maxparallel = 1
 
 moduleclass = 'perf'

--- a/easybuild/easyconfigs/o/OPARI2/OPARI2-1.1.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/o/OPARI2/OPARI2-1.1.2-foss-2015a.eb
@@ -19,9 +19,12 @@ description = """OPARI2, the successor of Forschungszentrum Juelich's OPARI,
 
 toolchain = {'name': 'foss', 'version': '2015a'}
 
-# http://www.vi-hps.org/upload/packages/opari2/opari2-1.1.1.tar.gz
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.vi-hps.org/upload/packages/opari2/']
+
+checksums = [
+    '9a262c7ca05ff0ab5f7775ae96f3539e',     # opari2-1.1.2.tar.gz
+]
 
 sanity_check_paths = {
     'files': ["bin/opari2", "include/opari2/pomp2_lib.h"],

--- a/easybuild/easyconfigs/o/OTF2/OTF2-1.5.1-foss-2015a.eb
+++ b/easybuild/easyconfigs/o/OTF2/OTF2-1.5.1-foss-2015a.eb
@@ -18,9 +18,12 @@ description = """The Open Trace Format 2 is a highly scalable, memory efficient 
 
 toolchain = {'name': 'foss', 'version': '2015a'}
 
-# http://www.vi-hps.org/upload/packages/otf2/otf2-1.2.1.tar.gz
 sources = [SOURCELOWER_TAR_GZ]
 source_urls = ['http://www.vi-hps.org/upload/packages/otf2/']
+
+checksums = [
+    '16a9df46e0da78e374f5d12c8cdc1109',     # otf2-1.5.1.tar.gz
+]
 
 sanity_check_paths = {
     # note by Bernd Mohr: on some systems libraries end up in lib/

--- a/easybuild/easyconfigs/p/PDT/PDT-3.20-foss-2015a.eb
+++ b/easybuild/easyconfigs/p/PDT/PDT-3.20-foss-2015a.eb
@@ -20,7 +20,6 @@ description = """Program Database Toolkit (PDT) is a framework for analyzing sou
 
 toolchain = {'name': 'foss', 'version': '2015a'}
 
-# http://tau.uoregon.edu/pdt_releases/pdtoolkit-3.19.tar.gz
 sources = ['pdtoolkit-%(version)s.tar.gz']
 source_urls = ['http://tau.uoregon.edu/pdt_releases/']
 

--- a/easybuild/easyconfigs/q/Qt/Qt-4.8.6-foss-2015a.eb
+++ b/easybuild/easyconfigs/q/Qt/Qt-4.8.6-foss-2015a.eb
@@ -7,8 +7,8 @@ description = "Qt is a comprehensive cross-platform C++ application framework."
 toolchain = {'name': 'foss', 'version': '2015a'}
 
 source_urls = [
-    'http://origin.releases.qt-project.org/qt4/source/',
-    'http://master.qt-project.org/archive/qt/%(version_major_minor)s/%(version)s/'
+    'http://download.qt.io/archive/qt/%(version_major_minor)s/%(version)s/',
+    'http://master.qt.io/archive/qt/%(version_major_minor)s/%(version)s/'
 ]
 sources = ['%(namelower)s-everywhere-opensource-src-%(version)s.tar.gz']
 

--- a/easybuild/easyconfigs/s/Scalasca/Scalasca-2.2-foss-2015a.eb
+++ b/easybuild/easyconfigs/s/Scalasca/Scalasca-2.2-foss-2015a.eb
@@ -21,7 +21,11 @@ toolchain = {'name': 'foss', 'version': '2015a'}
 toolchainopts = {"usempi": True}
 
 sources = [SOURCELOWER_TAR_GZ]
-source_urls = ['http://apps.fz-juelich.de/scalasca/releases/scalasca/%(version)s/dist']
+source_urls = ['http://apps.fz-juelich.de/scalasca/releases/scalasca/%(version_major_minor)s/dist']
+
+checksums = [
+    '06e0380c612811a1ff9c183fed9331a9',    # scalasca-2.2.tar.gz
+]
 
 dependencies = [
     ('Cube', '4.3'),

--- a/easybuild/easyconfigs/s/Score-P/Score-P-1.4-foss-2015a.eb
+++ b/easybuild/easyconfigs/s/Score-P/Score-P-1.4-foss-2015a.eb
@@ -20,9 +20,12 @@ description = """The Score-P measurement infrastructure is a highly scalable and
 toolchain = {'name': 'foss', 'version': '2015a'}
 toolchainopts = {"usempi": True}
 
-# http://www.vi-hps.org/upload/packages/scorep/scorep-1.2.1.tar.gz
 sources = ["scorep-%(version)s.tar.gz"]
 source_urls = ['http://www.vi-hps.org/upload/packages/scorep/']
+
+checksums = [
+    '17bd732cf54097d35157bf0d8284ad78',     # scorep-1.4.tar.gz
+]
 
 # compiler toolchain depencies
 dependencies = [
@@ -33,8 +36,6 @@ dependencies = [
     ('PAPI', '5.4.0'),
     ('PDT', '3.20'),
 ]
-
-maxparallel = 1
 
 sanity_check_paths = {
     'files': ["bin/scorep", "include/scorep/SCOREP_User.h",


### PR DESCRIPTION
Various tweaks (adjusted URLs, checksums, etc.).

The Cube easyconfig depends on a change to the Score-P easyblock provided by https://github.com/hpcugent/easybuild-easyblocks/pull/552

Remaining issue: Score-P is basically a runtime dependency of Scalasca. That is, it may make sense to automatically load a Score-P module from the Scalasca module. However, there is no real version dependency (Scalasca 2.2 works with Score-P 1.2 and higher). Don't know yet how to best address this.