### PR TITLE
include pkg-config as build dep for mc

### DIFF
--- a/easybuild/easyconfigs/m/mc/mc-4.8.13-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/m/mc/mc-4.8.13-GCC-4.9.2.eb
@@ -29,6 +29,7 @@ dependencies = [
 ]
 
 builddependencies = [
+    ('pkg-config', '0.28'),
     ('Automake', '1.15'),
     ('libtool', '2.4.5'),
 ]

--- a/easybuild/easyconfigs/p/pkg-config/pkg-config-0.28-GCC-4.9.2.eb
+++ b/easybuild/easyconfigs/p/pkg-config/pkg-config-0.28-GCC-4.9.2.eb
@@ -1,0 +1,27 @@
+easyblock = 'ConfigureMake'
+
+name = 'pkg-config'
+version = '0.28'
+
+homepage = 'http://www.freedesktop.org/wiki/Software/pkg-config/'
+description = """pkg-config is a helper tool used when compiling applications and libraries. It helps you insert the
+ correct compiler options on the command line so an application can use
+  gcc -o test test.c `pkg-config --libs --cflags glib-2.0`
+ for instance, rather than hard-coding values on where to find glib (or other libraries)."""
+
+# don't use PAX, it might break.
+tar_config_opts = True
+
+toolchain = {'name': 'GCC', 'version': '4.9.2'}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = ['http://pkgconfig.freedesktop.org/releases/']
+
+configopts = " --with-internal-glib"
+
+sanity_check_paths = {
+    'files': ['bin/pkg-config'],
+    'dirs': [],
+}
+
+moduleclass = 'devel'


### PR DESCRIPTION
suggestion by @rjeschmi (based on http://stackoverflow.com/questions/8811381/possibly-undefined-macro-ac-msg-error) for https://github.com/hpcugent/easybuild-easyconfigs/pull/1369, fixes the issue with building `mc`